### PR TITLE
fixed#19

### DIFF
--- a/f6b2-client/src/components/units/gardenDetail/GardenDetail.presenter.tsx
+++ b/f6b2-client/src/components/units/gardenDetail/GardenDetail.presenter.tsx
@@ -1,12 +1,9 @@
-import GardenCommentList from "../garden/comment/list/GardenCommentList.container";
-import GardenCommentWrite from "../garden/comment/write/GardenCommentWrite.container";
 import * as S from "./GardenDetail.styles";
-import { MdQuestionAnswer, MdThumbUp, MdBookmarkBorder } from "react-icons/md";
 import { getDate } from "../../../commons/libraries/utils";
-import { useQuery } from "@apollo/client";
-import { FETCH_COMMENTS } from "../../commons/queries";
+import { MdQuestionAnswer, MdThumbUp, MdBookmarkBorder } from "react-icons/md";
 
 export default function GardenDetailUI(props: any) {
+  console.log(props.data?.fetchBoard.commentsCount, "댓글수나오냐");
   return (
     <>
       <S.GardenWrapper>
@@ -28,10 +25,46 @@ export default function GardenDetailUI(props: any) {
             <S.ContentsBox>
               <S.Contents>{props.data?.fetchBoard.content}</S.Contents>
               {/* 번역API 버튼 자리? */}
-              {/* <S.ContentsTranslateBox>
+              <S.ContentsTranslateBox>
                 <S.ContentsTranslate>번역한 내용</S.ContentsTranslate>
-              </S.ContentsTranslateBox> */}
+              </S.ContentsTranslateBox>
               <S.ContentsImg />
+
+              {/* 댓글 부분 다시 수정할 것 */}
+              <S.LikeAndCommentCountBox>
+                {props.commentListVal ? (
+                  <S.CommentListBtn
+                    onClick={props.onClickCommentListBtn}
+                    id={props.data?.fetchBoard.id}
+                  >
+                    close
+                  </S.CommentListBtn>
+                ) : (
+                  <S.CommentListBtn
+                    onClick={props.onClickCommentListBtn}
+                    id={props.data?.fetchBoard.id}
+                  >
+                    open
+                  </S.CommentListBtn>
+                )}
+
+                <S.LikeAndCommentCount>
+                  <S.Like>
+                    <MdThumbUp
+                      size={"13"}
+                      style={{ marginRight: 5 }}
+                      onClick={props.onClickLikeBoard}
+                      id={props.data?.fetchBoard.id}
+                    />{" "}
+                    {props.data?.fetchBoard.likes}
+                  </S.Like>
+                  {/* 댓글 수 나옴 */}
+                  <S.CommentCount>
+                    <MdQuestionAnswer size={"13"} style={{ marginRight: 5 }} />
+                    {props.data?.fetchBoard.commentsCount}
+                  </S.CommentCount>
+                </S.LikeAndCommentCount>
+              </S.LikeAndCommentCountBox>
             </S.ContentsBox>
           </S.GardenListBox>
         </S.Wrapper>

--- a/f6b2-client/src/components/units/gardenDetail/GardenDetail.queries.ts
+++ b/f6b2-client/src/components/units/gardenDetail/GardenDetail.queries.ts
@@ -1,16 +1,19 @@
 import { gql } from "@apollo/client";
 
 export const FETCH_BOARD = gql`
-  query fetchBoard {
-    id
-    content
-    video
-    likes
-    writer {
+  query fetchBoard($boardId: String!) {
+    fetchBoard(boardId: $boardId) {
       id
-      name
+      content
+      video
+      likes
+      commentsCount
+      writer {
+        id
+        name
+      }
+      createdAt
     }
-    createdAt
   }
 `;
 

--- a/f6b2-client/src/components/units/gardenDetail/GardenDetail.styles.ts
+++ b/f6b2-client/src/components/units/gardenDetail/GardenDetail.styles.ts
@@ -44,7 +44,6 @@ export const WrapperRight = styled.div`
   top: 60px;
 `;
 
-
 export const GardenListBox = styled.main`
   width: 100%;
   padding: 30px;


### PR DESCRIPTION
feature-#19 가든 상세페이지 에러 업데이트

- 마이페이지-mygarden에서 게시물 누르면 상세페이지로 이동 완료
- 댓글 수도 나오게 수정 완료

##댓글불러오기가 안되는 상황입니다. props.commentListVal  코드 리뷰 듣고 진행하면 금방 불러올 수 있을 것 같습니다